### PR TITLE
Entry point, load/save pv list, miscellaneous fixes

### DIFF
--- a/adviewer/__init__.py
+++ b/adviewer/__init__.py
@@ -1,6 +1,25 @@
 from ._version import get_versions
-from .graph import *  # noqa
-from .utils import *  # noqa
+
+from . import discovery
+from . import graph
+from .graph import (PortTreeWidget, PortGraphMonitor, PortGraphFlowchart,
+                    PortGraphWindow)
+
+from . import utils
+from .utils import (break_cycles, position_nodes)
 
 __version__ = get_versions()['version']
 del get_versions
+
+__all__ = [
+    '__version__',
+    'discovery', 'graph',
+
+    'PortTreeWidget',
+    'PortGraphMonitor',
+    'PortGraphFlowchart',
+    'PortGraphWindow',
+
+    'break_cycles',
+    'position_nodes',
+    ]

--- a/adviewer/data_model.py
+++ b/adviewer/data_model.py
@@ -17,6 +17,19 @@ def register_model(ophyd_class):
 
 
 def get_node_data_model(cls):
+    '''
+    Get the most specific node data model associated with the given class.
+
+    Returns
+    -------
+    cls
+        A subclass of `qtpynodeeditor.NodeDataModel`
+
+    Raises
+    ------
+    ValueError
+        If there are no appropriate matches
+    '''
     if not inspect.isclass(cls):
         cls = cls.__class__
 

--- a/adviewer/device_model.py
+++ b/adviewer/device_model.py
@@ -39,11 +39,18 @@ class _DevicePollThread(QThread):
         while self.running:
             t0 = time.monotonic()
             for attr in list(attrs):
+                setpoint = None
                 try:
                     sig = getattr(self.device, attr)
+
+                    if hasattr(sig, 'get_setpoint'):
+                        setpoint = sig.get_setpoint()
+                    elif hasattr(sig, 'setpoint'):
+                        setpoint = sig.setpoint
+
                     self.data[attr].update(
                         readback=sig.get(),
-                        setpoint=getattr(sig, 'setpoint', ''),
+                        setpoint=setpoint,
                     )
                 except Exception:
                     logger.exception(

--- a/adviewer/device_model.py
+++ b/adviewer/device_model.py
@@ -250,11 +250,6 @@ class DeviceView(QtWidgets.QTableView):
 
             self.proxy_model.setSourceModel(model)
 
-            header = self.horizontalHeader()
-            for col in range(4):
-                header.setSectionResizeMode(
-                    col, QtWidgets.QHeaderView.ResizeToContents)
-
 
 class DeviceWidget(QtWidgets.QFrame):
     closed = Signal()

--- a/adviewer/device_model.py
+++ b/adviewer/device_model.py
@@ -190,6 +190,8 @@ class DeviceWidget(QtWidgets.QFrame):
     def __init__(self, device, parent=None):
         super().__init__(parent=parent)
 
+        self.setWindowTitle(device.name)
+
         self.setMinimumSize(500, 400)
 
         self.filter_label = QtWidgets.QLabel('&Filter')

--- a/adviewer/discovery.py
+++ b/adviewer/discovery.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 _RE_NONALPHA = re.compile('[^0-9a-zA-Z_]+')
+MIN_VERSION = '1.9.1'
+
 
 # semi-private dict in ophyd
 plugin_type_to_class = dict(areadetector.plugins._plugin_class)
@@ -102,6 +104,7 @@ def connect_to_many(prefix, pv_to_category_and_key, callback):
                      )
         for pv, (category, key) in pv_to_category_and_key.items()
     ]
+
     return status
 
 
@@ -148,6 +151,8 @@ def find_cams_over_channel_access(prefix, *, cam_re=r'cam\d:', max_count=2,
 
 def version_tuple_from_string(ver_string):
     'AD version string to tuple'
+    if ver_string is None:
+        raise ValueError('Version string cannot be None')
     return tuple(distutils.version.LooseVersion(ver_string).version)
 
 
@@ -160,7 +165,11 @@ def get_cam_from_info(manufacturer, model, *, adcore_version=None,
     cam_class = manufacturer_model_to_cam_class.get(
         (manufacturer, model), default_class)
 
+    if adcore_version is None:
+        adcore_version = MIN_VERSION
+
     adcore_version = version_tuple_from_string(adcore_version)
+
     if driver_version is not None:
         driver_version = version_tuple_from_string(driver_version)
     # TODO mix in new base components using adcore_version
@@ -318,11 +327,15 @@ def class_name_from_prefix(prefix):
     return class_name
 
 
-def cams_and_plugins_from_pvlist(pvs, callback):
+def cams_and_plugins_from_pvlist(pvs, cam_callback, plugin_callback, *,
+                                 min_version=None):
     '''
     Given a list of PVs from an AreaDetector IOC, search for cameras and
     plugins
     '''
+
+    if min_version is None:
+        min_version = MIN_VERSION
 
     def matching_prefixes(suffix):
         for pv in sorted(pvs):
@@ -331,10 +344,13 @@ def cams_and_plugins_from_pvlist(pvs, callback):
 
     version_pv_found = False
     cam_prefixes = list(matching_prefixes(':Manufacturer_RBV'))
+    plugin_prefixes = list(matching_prefixes(':PluginType_RBV'))
+    prefix = os.path.commonprefix(cam_prefixes + plugin_prefixes)
+
     cam_query = {}
 
     for idx, cam_prefix in enumerate(cam_prefixes, 1):
-        cam_category = f'cam{idx}'
+        cam_category = cam_prefix[len(prefix):]
         cam_query.update(
             {f'{cam_prefix}{suffix}': (cam_category, key)
              for suffix, key in (('Manufacturer_RBV', 'manufacturer'),
@@ -343,28 +359,30 @@ def cams_and_plugins_from_pvlist(pvs, callback):
                                  )
              }
         )
-        version_pv = f'{cam_prefix}ADCoreVersion_RBV'
-        if version_pv in pvs:
-            cam_query[version_pv] = (cam_category, 'version')
+        core_version_pv = f'{cam_prefix}ADCoreVersion_RBV'
+        if core_version_pv in pvs:
+            cam_query[core_version_pv] = (cam_category, 'adcore_version')
             version_pv_found = True
 
+        version_pv = f'{cam_prefix}DriverVersion_RBV'
+        if version_pv in pvs:
+            cam_query[version_pv] = (cam_category, 'driver_version')
+
     plugin_query = {
-        f'{prefix}PluginType_RBV': (f'plugin{idx}', 'plugin_type')
-        for idx, prefix in enumerate(matching_prefixes(':PluginType_RBV'), 1)
+        f'{plugin_prefix}PluginType_RBV': (plugin_prefix[len(prefix):],
+                                           'plugin_type')
+        for plugin_prefix in plugin_prefixes
     }
 
-    def inner_callback(pv, category, key, value, status):
-        return callback(pv=pv, category=category, key=key, value=value,
-                        status=status)
-
-    prefix = os.path.commonprefix(list(cam_query) + list(plugin_query))
-    cams = connect_to_many(prefix, cam_query, inner_callback)
+    cams = connect_to_many(prefix, cam_query, cam_callback)
     if not version_pv_found:
         # No ADCoreVersion found, assume the worst - R1-9-1
         for key, info_dict in cams.info.items():
-            info_dict['version'] = '1.9.1'
+            info_dict['adcore_version'] = min_version
+            cam_callback(pv=None, category=key, key='adcore_version',
+                         value=min_version, status=cams)
 
-    plugins = connect_to_many(prefix, plugin_query, inner_callback)
+    plugins = connect_to_many(prefix, plugin_query, plugin_callback)
     return cams, plugins
 
 

--- a/adviewer/discovery.py
+++ b/adviewer/discovery.py
@@ -384,24 +384,3 @@ def cams_and_plugins_from_pvlist(pvs, cam_callback, plugin_callback, *,
 
     plugins = connect_to_many(prefix, plugin_query, plugin_callback)
     return cams, plugins
-
-
-if __name__ == '__main__':
-    import sys
-    handler = logging.StreamHandler(sys.stdout)
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(handler)
-    logging.basicConfig()
-
-    # prefix = '13SIM1:'
-    # cams = find_cams_over_channel_access(prefix)
-    # plugins = find_plugins_over_channel_access(prefix)
-    # time.sleep(1.5)
-    # cls = create_detector_class(cams, plugins, default_core_version=(1, 9, 1))
-
-    def callback(*args, **kwargs):
-        # print('callback')
-        ...
-
-    pvlist = open('simdet.pvlist', 'rt').read().splitlines()
-    cams, plugins = cams_and_plugins_from_pvlist(pvlist, callback)

--- a/adviewer/graph.py
+++ b/adviewer/graph.py
@@ -28,7 +28,8 @@ class PortTreeWidget(QtWidgets.QTreeWidget):
         self.headerItem().setHidden(True)
 
         def item_changed(current, previous):
-            self.port_selected.emit(str(current.text(0)))
+            if current is not None:
+                self.port_selected.emit(str(current.text(0)))
 
         self.currentItemChanged.connect(item_changed)
 

--- a/adviewer/main.py
+++ b/adviewer/main.py
@@ -150,12 +150,12 @@ class DetectorModel(QtCore.QAbstractTableModel):
                         )
 
         elif role == Qt.DisplayRole:
-            columns = {
-                0: suffix,
-                1: info['class_'].__name__,
-                2: info['info'],
-            }
-            return str(columns[column])
+            if column == 0:
+                return suffix
+            if column == 1:
+                return info['class_'].__name__
+            if column == 2:
+                return '/'.join(info['info'].values())
 
     def columnCount(self, index):
         return 3

--- a/adviewer/main.py
+++ b/adviewer/main.py
@@ -288,6 +288,8 @@ class DiscoveryWidget(QtWidgets.QFrame):
     def __init__(self, prefix=None, parent=None):
         super().__init__(parent=parent)
 
+        self.setWindowTitle('adviewer: Channel Access search')
+
         self.setMinimumSize(500, 400)
 
         self.view = DetectorView(prefix=prefix)

--- a/adviewer/main.py
+++ b/adviewer/main.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import sys
 import threading
@@ -506,11 +507,48 @@ class DiscoveryWidget(QtWidgets.QFrame):
         self._code_editor = editor
 
 
-if __name__ == '__main__':
+def _build_arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.description = 'adviewer - AreaDetector configurator'
+
+    parser.add_argument(
+        'prefix',
+        type=str,
+        default='13SIM5:',
+        nargs='?',
+    )
+
+    parser.add_argument(
+        '--pvlist', '-p',
+        type=str,
+        default=None,
+    )
+
+    parser.add_argument(
+        '--log', '-l', dest='log_level',
+        default='DEBUG',
+        type=str,
+        help='Python logging level (e.g. DEBUG, INFO, WARNING)'
+    )
+
+    return parser
+
+
+def _entry_point():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    return main(**vars(args))
+
+
+def main(prefix, pvlist=None, *, log_level='DEBUG'):
+    logger = logging.getLogger('pytmc')
+    logger.setLevel(log_level)
     logging.basicConfig()
-    logger.setLevel('DEBUG')
+
     app = QtWidgets.QApplication(sys.argv)
-    w = DiscoveryWidget()  # prefix='13SIM1:')
-    w.show()
-    w.load_pvlist('simdet.pvlist')
+    widget = DiscoveryWidget(prefix)
+    if pvlist is not None:
+        widget.load_pvlist(pvlist)
+
+    widget.show()
     app.exec_()

--- a/adviewer/utils.py
+++ b/adviewer/utils.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 import logging
 
 import networkx
@@ -88,3 +89,16 @@ def position_nodes(edges, port_map, *, x_spacing, y_spacing, x=0, y=0):
             position_port(port, start_x, get_next_y())
 
     return positions
+
+
+def locked(func):
+    '''
+    Instance method decorator which wraps a method call in a `with self.lock`
+    block.
+    '''
+    @functools.wraps(func)
+    def wrapped(self, *args, **kwargs):
+        with self.lock:
+            return func(self, *args, **kwargs)
+
+    return wrapped

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,9 @@ setup(
     url='https://github.com/pcdshub/adviewer',
     entry_points={
         'console_scripts': [
-            # 'some.module:some_function',
-            ],
-        },
+            'adviewer = adviewer.main:_entry_point',
+        ],
+    },
     include_package_data=True,
     package_data={
         'adviewer': [


### PR DESCRIPTION
* `adviewer` command-line entry-point
* Discovery window will load from or save to a PV list (i.e., will load PV names directly from `dbl > ad.pvlist`)
* Clean/remove debug code
* Allow changing setpoints in the DeviceView table